### PR TITLE
Fix bug: Empty command output causes unhandled exception

### DIFF
--- a/hoaxshell.py
+++ b/hoaxshell.py
@@ -301,22 +301,25 @@ class Hoaxshell(BaseHTTPRequestHandler):
 			content_len = int(self.headers.get('Content-Length'))
 			output = self.rfile.read(content_len)
 			
-			try:
-				bin_output = output.decode('utf-8').split(' ')
-				to_b_numbers = [ int(n) for n in bin_output ]
-				b_array = bytearray(to_b_numbers)
-				output = b_array.decode('utf-8', 'ignore')
-				
-			except UnicodeDecodeError:
-				print(f'[{WARN}] Decoding data to UTF-8 failed. Printing raw data.')
-			
-			if isinstance(output, bytes):
-				pass
-				
+			if output:
+				try:
+					bin_output = output.decode('utf-8').split(' ')
+					to_b_numbers = [ int(n) for n in bin_output ]
+					b_array = bytearray(to_b_numbers)
+					output = b_array.decode('utf-8', 'ignore')
+
+				except UnicodeDecodeError:
+					print(f'[{WARN}] Decoding data to UTF-8 failed. Printing raw data.')
+
+				if isinstance(output, bytes):
+					pass
+
+				else:
+					output = output.strip() + '\n' if output.strip() != '' else output.strip()
+					
+				print(f'\r{GREEN}{output}{END}')
 			else:
-				output = output.strip() + '\n' if output.strip() != '' else output.strip()
-				
-			print(f'\r{GREEN}{output}{END}') if output not in [None, ''] else print(f'\r{ORANGE}No output.{END}')
+				print(f'\r{ORANGE}No output.{END}')
 			
 			Hoaxshell.prompt_ready = True
 	


### PR DESCRIPTION
Some commands like 'cd' return no output at all so the program crashes.

```
hoaxshell > cd Desktop
----------------------------------------
Exception happened during processing of request from ('192.168.0.9', 50105)
Traceback (most recent call last):
  File "/usr/lib/python3.8/socketserver.py", line 316, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python3.8/socketserver.py", line 347, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python3.8/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.8/socketserver.py", line 747, in __init__
    self.handle()
  File "/usr/lib/python3.8/http/server.py", line 427, in handle
    self.handle_one_request()
  File "/usr/lib/python3.8/http/server.py", line 415, in handle_one_request
    method()
  File "hoaxshell.py", line 306, in do_POST
    to_b_numbers = [ int(n) for n in bin_output ]
  File "hoaxshell.py", line 306, in <listcomp>
    to_b_numbers = [ int(n) for n in bin_output ]
ValueError: invalid literal for int() with base 10: ''
```
