### PR TITLE
Added on-the-fly crypto and --ssl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ When you run hoaxshell, it will generate its own PowerShell payload for you to c
 
 #### Encrypted shell session (https):
 ```
-# Generate self-signed certificate:
+# Generate self-signed certificate automatically:
+sudo python3 hoaxshell.py -s <your_ip> --ssl
+
+-------------------------------------------------
+
+# Generate self-signed certificate manually:
 openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365
 
 # Pass the cert.pem and key.pem as arguments:

--- a/generate_key_and_cert.py
+++ b/generate_key_and_cert.py
@@ -1,0 +1,86 @@
+import cryptography.hazmat.primitives.asymmetric.rsa
+import datetime
+
+def generate_private_key():
+	#Generate Key with "cryptography" (https://pypi.org/project/cryptography/)
+	#Using full package paths for clarity.  This can be reduced with additional imports above.
+	key = cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key(
+		public_exponent=65537,
+		key_size=2048,
+		)
+	#Write to a file in the local directory.
+	key_filename = "default_hoaxshell.pem"
+
+	with open(key_filename,"wb") as f:
+		f.write(key.private_bytes(
+			encoding = cryptography.hazmat.primitives.serialization.Encoding.PEM,
+			format = cryptography.hazmat.primitives.serialization.PrivateFormat.TraditionalOpenSSL,
+			#Using NoEncryption here for a default key, but this can be changed to BestAvailableEncryption(b"password") if needed
+			encryption_algorithm = cryptography.hazmat.primitives.serialization.NoEncryption(),
+			))
+	return key,key_filename
+
+def generate_cert_from_key(key,certname="default_hoaxshell.crt"):
+	#Generate self-signed cert
+	#Custom serial for IOC purposes
+	serial = int('40ac5431140ac5431140ac5431140ac5431140a',16)
+
+	#Get current time
+	iss_time = datetime.datetime.now()
+
+	#Explicitly define name for IOC purposes
+	subject = cryptography.x509.Name([
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.COUNTRY_NAME,u'US'),
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.STATE_OR_PROVINCE_NAME,u'Texas'),
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.LOCALITY_NAME,u'Nowhere'),
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.ORGANIZATION_NAME,u'default_hoaxshell'),
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.ORGANIZATIONAL_UNIT_NAME,u'default_hoaxshell'),
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.COMMON_NAME,u'default_hoaxshell'),
+		])
+	issuer = cryptography.x509.Name([
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.COUNTRY_NAME,u'US'),
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.ORGANIZATION_NAME,u'default_hoaxshell'),
+		cryptography.x509.NameAttribute(cryptography.x509.oid.NameOID.COMMON_NAME,u'default_hoaxshell'),
+		])
+	cert = cryptography.x509.CertificateBuilder().subject_name(subject
+		).issuer_name(
+			issuer
+		).public_key(
+			key.public_key()
+		).serial_number(
+			serial
+		).not_valid_before(
+			iss_time
+		).not_valid_after(
+			iss_time + datetime.timedelta(days=365)
+		).add_extension(
+			cryptography.x509.CRLDistributionPoints([
+				cryptography.x509.DistributionPoint(
+					full_name=[
+						#Shout out to the Github Repo
+						cryptography.x509.UniformResourceIdentifier(u'https://github.com/t3l3machus/hoaxshell'),
+						cryptography.x509.UniformResourceIdentifier(u'https://github.com/t3l3machus/hoaxshell')
+					],
+					relative_name=None,
+					crl_issuer=None,
+					reasons=None
+					),
+			]),
+			critical=False
+		#Finally (self-)sign the certificate
+		).sign(key,cryptography.hazmat.primitives.hashes.SHA256())
+
+	#Write certificate to file in local directory
+	with open(f'{certname}','wb') as f:
+		f.write(cert.public_bytes(cryptography.hazmat.primitives.serialization.Encoding.PEM))
+	return certname
+
+def generate():
+	#Generate the key object and file
+	key,key_filename = generate_private_key()
+	#Generate the cert object and file
+	cert_filename = generate_cert_from_key(key)
+	return key_filename,cert_filename
+
+if __name__ == '__main__':
+	pass

--- a/hoaxshell.py
+++ b/hoaxshell.py
@@ -82,7 +82,7 @@ if args.port:
 if (args.certfile and not args.keyfile) or (args.keyfile and not args.certfile):
 		exit_with_msg('Failed to start over https. Missing key or cert file (check -h for more details).')
 # If not, check if SSL is requested
-if args.ssl:
+if args.ssl and not (args.certfile and args.keyfile):
 	args.keyfile,args.certfile = generate_key_and_cert.generate()
 
 ssl_support = True if args.certfile and args.keyfile else False

--- a/hoaxshell.py
+++ b/hoaxshell.py
@@ -13,6 +13,8 @@ from threading import Thread, Event
 from time import sleep
 from ipaddress import ip_address
 from subprocess import check_output
+#import from local directory
+import generate_key_and_cert
 
 filterwarnings("ignore", category = DeprecationWarning)
 
@@ -61,6 +63,7 @@ parser.add_argument("-r", "--raw-payload", action="store_true", help = "Generate
 parser.add_argument("-g", "--grab", action="store_true", help = "Attempts to restore a live session (Default: false)")
 parser.add_argument("-u", "--update", action="store_true", help = "Pull the latest version from the original repo")
 parser.add_argument("-q", "--quiet", action="store_true", help = "Do not print the banner on startup")
+parser.add_argument("--ssl", action="store_true", help = "Generate a private key and self-signed certificate on-the-fly")
 
 args = parser.parse_args()
 
@@ -77,7 +80,10 @@ if args.port:
 
 # Check if both cert and key files were provided
 if (args.certfile and not args.keyfile) or (args.keyfile and not args.certfile):
-	exit_with_msg('Failed to start over https. Missing key or cert file (check -h for more details).')
+		exit_with_msg('Failed to start over https. Missing key or cert file (check -h for more details).')
+# If not, check if SSL is requested
+if args.ssl:
+	args.keyfile,args.certfile = generate_key_and_cert.generate()
 
 ssl_support = True if args.certfile and args.keyfile else False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ipython==8.4.0
+cryptography


### PR DESCRIPTION
Hey there, I noticed that the HTTPS option required OpenSSL or the user to create their own private key and certificate.  I added the --ssl option from the command line and an import file that uses "cryptography" to create a private key and certificate in the same directory as hoaxshell.  

If --ssl is provided with a key and cert file, we use the supplied args.  If not, it generates a key (unencrypted) and cert on-the-fly.  Hopefully this lowers the barrier-to-entry for use of encryption with this shell to prevent data leaks.