### PR TITLE
Add readline support for Windows OS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ipython==8.4.0
+pyreadline


### PR DESCRIPTION
Hey! 

Read line does not work on Windows except if you include the `pyreadline` in the requirements file 👍 
![image](https://user-images.githubusercontent.com/40599884/186746283-c28d2f28-bb56-4b01-8241-b26d71324113.png)
